### PR TITLE
Anti Aliasing For Line Draw

### DIFF
--- a/utils/public_gpu.py
+++ b/utils/public_gpu.py
@@ -34,7 +34,8 @@ def draw_line(verts, color, line_width, is_cycle=True):
             colors.append(color)
             pos.append(verts[index + 1])
     shader.bind()
-
+    
+    gpu.state.blend_set("ALPHA")
     batch = batch_for_shader(shader, 'LINES', {"pos": pos, "color": colors})
     batch.draw(shader)
 


### PR DESCRIPTION
Adds Anti Aliasing and opacity For Line Draw

Examples:
(the red dot is just becouse I captured the images with screen recording) 

Before:
![image](https://github.com/user-attachments/assets/c1d458da-7609-421b-9461-ff761c16c7c3)
![image](https://github.com/user-attachments/assets/5a161b60-de59-4b4b-9617-d7e68bc88f10)

After:
![image](https://github.com/user-attachments/assets/4112bfe2-6091-4637-9aa7-9e9176b1c108)
![image](https://github.com/user-attachments/assets/018b83ff-a0cd-4385-8b89-0124763bc724)

The line now also supports opacity:
![image](https://github.com/user-attachments/assets/7dca0ae7-72d0-43f4-bed8-10c2e50182ff)
