### PR TITLE
Fix modal UI placement and element cut crash.

### DIFF
--- a/element/element_cure.py
+++ b/element/element_cure.py
@@ -278,8 +278,17 @@ class ElementCURE:
             # Select item to cut
             ae = self.pref.active_element
             ElementCURE.CUT.__cut_data__ = ae.___dict_data___
+            is_last = ae.is_last
+            parent = ae.parent
+            index = ae.index
             ae.remove()
-            print(ae, self.active_element, ElementCURE.CUT.__cut_data__)
+
+            if is_last and index != 0:
+                parent.index_element = index - 1
+                parent.element[parent.index_element].radio = True
+            elif -1 < index < len(parent.element):
+                parent.element[index].radio = True
+
             self.cache_clear()
             return {'FINISHED'}
 

--- a/element/element_draw.py
+++ b/element/element_draw.py
@@ -86,7 +86,7 @@ class ElementDraw:
                 element.draw_item(child)
             child.separator()
 
-    def draw_item_property(self, layout: 'bpy.types.UILayout') -> None:
+    def draw_item_property(self, layout: 'bpy.types.UILayout', *, include_modal: bool = True) -> None:
         if self.is_selected_structure:
             from ..ops.set_poll import SetPollExpression
             icon = self.pref.__get_icon__(self.selected_type)
@@ -101,6 +101,8 @@ class ElementDraw:
             row.prop(self, 'selected_type', expand=True)
         elif self.is_operator:
             self.draw_operator(layout)
+            if include_modal and self.operator_is_modal:
+                self.draw_operator_modal(layout)
         elif self.is_child_gesture:
             row = layout.row(align=True)
             column = row.column()
@@ -236,8 +238,6 @@ class ElementDraw:
                     column.alert = True
                     column.label(text='Not recommended as modal operator', icon='ERROR')
                     column.label(text='The operator contains array properties and cannot be controlled')
-
-            #     self.draw_operator_modal(layout)
 
     def draw_operator_modal(self, layout):
         from .element_modal_operator_cure import ElementModalOperatorEventCRUE

--- a/element/element_relationship.py
+++ b/element/element_relationship.py
@@ -125,20 +125,30 @@ class Relationship:
 class RadioSelect:
     @cache_update_lock
     def update_radio(self):
-        try:
-            for (index, element) in enumerate(self.parent_gesture.element):
-                if self.root_parent == element:
-                    self.parent_gesture.index_element = index
+        gesture = self.parent_gesture
+        if gesture is None:
+            self.cache_clear()
+            gesture = self.parent_gesture
+        if gesture is None:
+            return
 
-            if not self.is_root:  # Set child gesture index
-                for index, e in enumerate(self.collection):
-                    if e == self:
-                        self.parent.index_element = index
+        try:
+            for (index, element) in enumerate(gesture.element):
+                if self.root_parent == element:
+                    gesture.index_element = index
+
+            if not self.is_root:
+                collection = self.collection
+                if collection is not None:
+                    for index, e in enumerate(collection):
+                        if e == self:
+                            self.parent.index_element = index
+                            break
 
             for item in self.radio_iteration:
                 is_select = item == self
                 item['radio'] = is_select
-                if is_select and self.is_operator:  # Update KMI when operator is selected
+                if is_select and self.is_operator:
                     self.to_operator_tmp_kmi()
         except Exception as e:
             self.cache_clear()
@@ -151,7 +161,10 @@ class RadioSelect:
 
     @property
     def radio_iteration(self):
-        return self.parent_gesture.element_iteration
+        gesture = self.parent_gesture
+        if gesture is None:
+            return []
+        return gesture.element_iteration
 
 
 class ElementRelationship(RadioSelect,

--- a/preferences/add_element.py
+++ b/preferences/add_element.py
@@ -4,7 +4,6 @@ import bpy
 
 from ..element.element_property import ElementAddProperty
 from ..utils.enum import ENUM_RELATIONSHIP
-from ..utils.public import get_pref
 
 class AddElementProperty(ElementAddProperty, bpy.types.PropertyGroup):
     add_active_radio: bpy.props.BoolProperty(name="Whether or not to set it as an active item when adding an element",
@@ -23,15 +22,8 @@ class AddElementProperty(ElementAddProperty, bpy.types.PropertyGroup):
     @contextmanager
     def active_radio(self):
         last_active_radio = self.add_active_radio
-        active = get_pref().active_element
         try:
             self.add_active_radio = True
             yield
         finally:
             self.add_active_radio = last_active_radio
-            if active and not last_active_radio:
-                active.cache_clear()
-                active.radio = True
-                active.cache_clear()
-                active.update_radio()
-                active.cache_clear()

--- a/preferences/draw_element.py
+++ b/preferences/draw_element.py
@@ -48,7 +48,7 @@ class DrawElement:
         column.prop(draw_property, 'element_show_left_side', icon=icon, text='', emboss=False)
 
     @staticmethod
-    def draw_property(layout: 'bpy.types.UILayout') -> None:
+    def draw_property(layout: 'bpy.types.UILayout', *, include_modal: bool = True) -> None:
         pref = get_pref()
         active_element = pref.active_element
         prop = pref.draw_property
@@ -61,7 +61,7 @@ class DrawElement:
                 DrawElement.draw_move_element(layout)
             elif not prop.element_show_left_side:
                 active_element.draw_alert(layout)
-                active_element.draw_item_property(layout)
+                active_element.draw_item_property(layout, include_modal=include_modal)
             if get_debug():
                 active_element.draw_debug(layout)
         else:

--- a/preferences/draw_gesture.py
+++ b/preferences/draw_gesture.py
@@ -70,7 +70,7 @@ class GestureDraw:
         GestureDraw.draw_gesture_key(column)
 
     @staticmethod
-    def draw_element(layout: bpy.types.UILayout) -> None:
+    def draw_element(layout: bpy.types.UILayout, *, include_modal: bool = True) -> None:
         from ..ui.ui_list import ElementUIList
 
         pref = get_pref()
@@ -90,7 +90,7 @@ class GestureDraw:
                 ag,
                 'index_element',
             )
-            DrawElement.draw_property(sub_column)
+            DrawElement.draw_property(sub_column, include_modal=include_modal)
 
             DrawElement.draw_element_cure(row)
         else:

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -53,7 +53,7 @@ class GestureElementPanel(bpy.types.Panel, PublicProperty):
     def draw(self, context):
         layout = self.layout
         layout.enabled = self.pref.enabled
-        GestureDraw.draw_element(layout)
+        GestureDraw.draw_element(layout, include_modal=False)
 
 
 class GestureModalEventPanel(bpy.types.Panel, PublicProperty):


### PR DESCRIPTION
Restore modal event editing in preferences while keeping it in the dedicated N-panel, and prevent cut from accessing stale RNA after remove.