### PR TITLE
fix(ui): replace direct icon constants with ui_icon function calls

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -24,8 +24,8 @@ with bundled JSON presets, translations, and PNG icon assets.
   declaration and fails immediately instead of importing presets into a stale
   schema.
 - `utils/rna_register.py` provides reload-tolerant class registration. The
-  package build excludes tests, documentation, VCS files, caches, and agent
-  files via `[build].paths_exclude_pattern`.
+  package build excludes tests, release notes, documentation, VCS files,
+  caches, and agent files via `[build].paths_exclude_pattern`.
 
 ### Runtime data and persistence
 
@@ -297,6 +297,10 @@ with bundled JSON presets, translations, and PNG icon assets.
   both states of layout alignment, property drag inversion, property value
   visibility, and boolean state icons. `src/translate/` holds locale JSON and translation
   caches; `src/icons/` holds numbered, color, and Blender-derived PNG icons.
+  Every explicit Blender `UILayout` `icon=` argument passes through
+  `utils/icons.py:ui_icon()`, which validates the identifier against the live
+  Blender enum and falls back to `ERROR`; `tests/test_ui_icons.py` guards this
+  contract across UI source modules.
 - The normal `Common Menu` preset is enabled on `BUTTON4MOUSE` in 19 relevant
   3D View/mode keymaps. Its compact, keep-open menu filters mode and object-type
   sections at runtime and groups viewport display, mode switching, object and
@@ -355,8 +359,10 @@ flowchart TD
   panel behavior. Run them
   with isolated `BLENDER_USER_CONFIG`, `BLENDER_USER_DATAFILES`,
   `BLENDER_USER_SCRIPTS`, and `BLENDER_USER_EXTENSIONS`, plus `--background
-  --python-exit-code 1`. Treat traceback/Python-error text as failure evidence
-  even when Blender exits zero.
+  --python-exit-code 1`. Create all four target directories before launching
+  Blender; nonexistent override paths are ignored and silently fall back to
+  the normal user profile. Treat traceback/Python-error text as failure
+  evidence even when Blender exits zero.
 - Focused example-keymap, selector-close, and numeric-hover verification:
   `tests/blender_keymap_selector_hover_smoke.py`; it explicitly enables and
   restores Blender's numeric-arrow preference instead of assuming its default.
@@ -377,41 +383,38 @@ flowchart TD
   requests/second.
 - Release: run Blender `--command extension validate`, then `extension build`,
   inspect ZIP entries, and validate the produced archive again.
-- Previous release-candidate verification on 2026-07-29: 173 Python files compiled in
-  memory, 272 unit tests passed, Ruff and `git diff --check` passed, and all 16
-  source JSON files passed duplicate-key validation. Nine isolated background
-  smoke scripts passed in both Blender 4.3.2 and 5.2.0 LTS with zero
-  tracebacks/Python errors. Both CLIs validated source and the 5.2-built ZIP;
-  its 344 entries had no duplicates, unsafe paths, forbidden agent/test/cache
-  files, `eval`/`exec` calls, or corruption. SHA-256 is
-  `5098A577F44CCC3F0F2001620FC7B64D34364E3CBF54BA4B4AB1E389456161D6`.
+- Release-candidate verification on 2026-07-30: all 184 repository Python files
+  compiled in memory, 328 unit tests passed, Ruff and `git diff --check` passed,
+  and all 17 JSON files passed duplicate-key validation. Eleven isolated source
+  smoke scripts passed in Blender 4.3.2. Ten non-file-load source smokes passed
+  in Blender 5.2.0 LTS; its lifecycle smoke is blocked because that Blender
+  binary reproducibly crashes inside `bpy.ops.wm.read_homefile(use_empty=True)`
+  even in a minimal factory-startup process with no add-on enabled. Both CLIs
+  validated the source and the 5.2-built flat ZIP. The archive has 348 entries,
+  no duplicates, unsafe paths, forbidden agent/test/cache files,
+  `svg_2_png.py`, `eval`/`exec` calls, or corruption; SHA-256 is
+  `FAE3EEE1BC1518C321CA8AE36B8ECFB6F7516BA61D5FF42FA4D292837A5E663A`.
   The ZIP installed into isolated local Extension repositories, started
-  enabled, imported all 11 bundled presets, exposed the current `SPLIT` RNA,
-  and disabled cleanly in Blender 4.3 and 5.2.
-- Current-tree focused verification for `Common Menu` passed its four structural
-  tests and the source duplicate-key check. Its dedicated smoke and the complete
-  12-preset transactional import/keymap smoke passed in isolated Blender 4.3.2
-  and 5.2.0 LTS profiles. The complete release/build/package suite has not been
-  rerun since the previous baseline.
+  enabled, imported all 12 bundled presets, exposed the current `SPLIT` RNA,
+  and disabled cleanly in Blender 4.3.2 and 5.2.0 LTS.
 
 ## Current risks and observed issues
 
-1. **Submission asset-license decision remains open:** the bundled
-   `CHECKBOX_HLT`/`CHECKBOX_DEHLT` images are declared as Blender-derived GPL
-   assets, while the Nick review guidance expects submitted artwork to meet its
-   CC0 threshold. Do not change their provenance or license without an explicit
-   release decision.
+1. **Bundled asset provenance must stay explicit:** the Blender-derived icon
+   files are covered by `src/icons/blender/NOTICE.txt`, the GPL-compatible
+   extension license, and the Blender Foundation manifest credit. Preserve that
+   provenance if the images are regenerated or replaced.
 2. **Blender-exit detection depends on Python stack internals:**
    `utils/__init__.py:is_blender_close()` uses `sys._getframe()` and searches for
    an `addon_utils.disable_all` caller. It currently passes lifecycle smoke but
    depends on implementation details that may change in later Blender/Python.
-3. **Blender-only behavior remains higher risk than unit coverage:** focused
-   example-preset and unified-preview verification, including layout RNA and
-   drawing, passes in Blender 4.3.2 and 5.2.0 LTS. The installed 5.2 build has
-   previously aborted with a native access violation before Python assertions,
-   so native instability may be intermittent. Foreground visual placement,
-   multi-window behavior, and file-load restoration still require targeted
-   manual checks.
+3. **Current Blender 5.2 binary cannot exercise file reload:** its
+   `bpy.ops.wm.read_homefile(use_empty=True)` path deterministically aborts in
+   `tbbmalloc.dll`, including without Gesture Helper. The full lifecycle/reload
+   smoke passes in Blender 4.3.2, and the other ten 5.2 source smokes plus the
+   installed-package smoke pass. Re-run the lifecycle smoke when a newer 5.2
+   build is available. Foreground visual placement and multi-window behavior
+   still require targeted manual checks.
 4. **Broad lifecycle surface:** modal timers, GPU draw handlers, playback/load
    handlers, cached RNA proxies, and `SKIP_SAVE` restoration all share cleanup
    paths. Any future change in `register_mod.py`, `gesture_session.py`,

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -28,6 +28,7 @@ paths_exclude_pattern = [
     "/.agents/",
     "/AGENTS.md",
     "/PROJECT_CONTEXT.md",
+    "/release-notes/",
     "/.ruff_cache/",
     "/.tmp/",
     "/.smoke_blender_userdata/",
@@ -51,4 +52,4 @@ paths_exclude_pattern = [
 
 [permissions]
 files = "Read/write gestures, backups, custom icons, and preference files"
-clipboard = "Copy selected icon names to the clipboard"
+clipboard = "Copy icon names, property paths, and visible tooltip text"

--- a/element/element_draw.py
+++ b/element/element_draw.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.app.translations import pgettext_iface
 
 from ..ops.set_direction import SetDirection
+from ..utils.icons import ui_icon
 from ..utils.public import get_pref
 from ..utils.public_ui import icon_two
 
@@ -20,7 +21,11 @@ class ElementDraw:
         row.prop(self, 'name')
         if self.can_sync_name:
             row.context_pointer_set('gesture_name_element', self)
-            row.operator(SyncElementName.bl_idname, text='', icon='FILE_REFRESH')
+            row.operator(
+                SyncElementName.bl_idname,
+                text='',
+                icon=ui_icon('FILE_REFRESH'),
+            )
 
     def draw_overlay_offset(self, layout: 'bpy.types.UILayout') -> None:
         # Offsets are a radial root-placement setting.  Keep the persisted RNA
@@ -90,27 +95,36 @@ class ElementDraw:
             r = controls.row(align=True)
             r.ui_units_x = 1.0
             r.active = r.enabled = self.is_movable
-            r.operator(ElementCURE.MOVE.bl_idname, text="", icon="UV_SYNC_SELECT", emboss=False)
+            r.operator(
+                ElementCURE.MOVE.bl_idname,
+                text="",
+                icon=ui_icon("UV_SYNC_SELECT"),
+                emboss=False,
+            )
         elif pref.__is_cut_element__:
             from .element_cure import ElementCURE
             r = controls.row(align=True)
             r.ui_units_x = 1.0
             r.active = r.enabled = self.is_can_be_cut
-            r.operator(ElementCURE.CUT.bl_idname, text="", icon="PASTEFLIPDOWN", emboss=False)
+            r.operator(
+                ElementCURE.CUT.bl_idname,
+                text="",
+                icon=ui_icon("PASTEFLIPDOWN"),
+                emboss=False,
+            )
         if _draw_children:
             self.draw_item_child(column, active, frozen=_frozen)
 
     def draw_item_left(self, layout: 'bpy.types.UILayout', pref=None):
-        from ..utils.icons import ui_icon
         if pref is None:
             pref = get_pref()
         row = layout.row()
         if pref.draw_property.element_show_enabled_button:
             row.prop(self, 'enabled', text='')
         if self.is_operator:
-            row.label(text='', icon='GEOMETRY_NODES')
+            row.label(text='', icon=ui_icon('GEOMETRY_NODES'))
         elif self.is_child_gesture:
-            row.label(text='', icon='CON_CHILDOF')
+            row.label(text='', icon=ui_icon('CON_CHILDOF'))
         elif self.is_selected_structure:
             row.label(text='', icon_value=pref.__get_icon__(self.selected_type))
         elif self.is_dividing_line:
@@ -128,21 +142,21 @@ class ElementDraw:
         elif self.is_split:
             row.label(text='', icon=ui_icon('SPLIT_HORIZONTAL'))
         else:
-            row.label(text='', icon='BLANK1')
+            row.label(text='', icon=ui_icon('BLANK1'))
 
         in_panel = self.parent_is_extension or self.parent_is_layout
         if in_panel:  # Panel children: hide direction icon
             if self.is_child_gesture:
                 row.label(text='', icon_value=pref.__get_icon__("MENU_PANEL"))
             else:
-                row.label(text='', icon='BLANK1')
+                row.label(text='', icon=ui_icon('BLANK1'))
         elif (
                 self.is_child_gesture or self.is_operator
                 or self.is_property_display or self.is_layout_container
         ):
             row.label(text='', icon_value=pref.__get_icon__(self.direction))
         else:
-            row.label(text='', icon='BLANK1')
+            row.label(text='', icon=ui_icon('BLANK1'))
 
     def draw_item_right(
             self,
@@ -164,7 +178,7 @@ class ElementDraw:
                 'READ_ONLY_PROPERTY': 'LOCKED',
                 'DISABLED': 'HIDE_OFF',
             }.get(status_info.status.name, 'ERROR')
-            status_row.label(text=status_info.badge, icon=status_icon)
+            status_row.label(text=status_info.badge, icon=ui_icon(status_icon))
         else:
             status_row.label(text='')
 
@@ -175,11 +189,11 @@ class ElementDraw:
                 self,
                 'show_child',
                 text='',
-                icon=icon_two(self.show_child, 'TRI'),
+                icon=ui_icon(icon_two(self.show_child, 'TRI')),
                 emboss=False,
             )
         else:
-            child_row.label(text='', icon='BLANK1')
+            child_row.label(text='', icon=ui_icon('BLANK1'))
 
         if show_icon:
             icon_row = controls.row(align=True)
@@ -192,7 +206,7 @@ class ElementDraw:
             self,
             'radio',
             text='',
-            icon=icon_two(self.radio, 'RESTRICT_SELECT'),
+            icon=ui_icon(icon_two(self.radio, 'RESTRICT_SELECT')),
             emboss=False,
         )
 
@@ -218,7 +232,7 @@ class ElementDraw:
             row = layout.row()
             row.label(text='Structure element', icon_value=icon)
             row.operator_context = "INVOKE_DEFAULT"
-            row.operator(SetPollExpression.bl_idname, icon='FILTER')
+            row.operator(SetPollExpression.bl_idname, icon=ui_icon('FILTER'))
             layout.prop(self, 'poll_string')
             row = layout.row(align=True)
             row.prop(self, 'selected_type', expand=True)
@@ -264,7 +278,7 @@ class ElementDraw:
         else:
             alert = column.column(align=True)
             alert.alert = True
-            alert.label(text='Property path not found', icon='ERROR')
+            alert.label(text='Property path not found', icon=ui_icon('ERROR'))
         if not (self.parent_is_extension or self.parent_is_layout):
             SetDirection.draw_direction(row.column())
 
@@ -273,7 +287,9 @@ class ElementDraw:
             self,
             'show_property_advanced',
             text='Property Settings',
-            icon='TRIA_DOWN' if self.show_property_advanced else 'TRIA_RIGHT',
+            icon=ui_icon(
+                'TRIA_DOWN' if self.show_property_advanced else 'TRIA_RIGHT'
+            ),
             emboss=False,
         )
         if self.show_property_advanced:
@@ -286,7 +302,12 @@ class ElementDraw:
             if prop_type in {'INT', 'FLOAT'}:
                 drag = advanced.row(align=True)
                 drag.prop(self, 'property_drag_mode', text='')
-                drag.prop(self, 'property_drag_invert', text='', icon='ARROW_LEFTRIGHT')
+                drag.prop(
+                    self,
+                    'property_drag_invert',
+                    text='',
+                    icon=ui_icon('ARROW_LEFTRIGHT'),
+                )
                 advanced.prop(self, 'property_wheel_step')
                 if prop_type == 'FLOAT' and self.property_show_value:
                     advanced.prop(self, 'property_value_precision')
@@ -313,13 +334,16 @@ class ElementDraw:
             icon = getattr(self, prop_name)
             cell = row.row(align=True)
             cell.prop(self, prop_name, text=label, **icon_layout_kwargs(icon))
-            operator = cell.operator(SelectIcon.bl_idname, text='', icon='RESTRICT_SELECT_OFF')
+            operator = cell.operator(
+                SelectIcon.bl_idname,
+                text='',
+                icon=ui_icon('RESTRICT_SELECT_OFF'),
+            )
             operator.target = target
 
     def draw_layout_container(self, layout: 'bpy.types.UILayout') -> None:
         from ..element.element_cure import ElementCURE
         from ..utils.enum import ENUM_LAYOUT_TYPE
-        from ..utils.icons import ui_icon
         row = layout.row(align=True)
         column = row.column(align=True)
         self.draw_name(column)
@@ -422,7 +446,9 @@ class ElementDraw:
             self,
             'main_item',
             text='Gesture Action',
-            icon='RADIOBUT_ON' if owner.main_element == self else 'RADIOBUT_OFF',
+            icon=ui_icon(
+                'RADIOBUT_ON' if owner.main_element == self else 'RADIOBUT_OFF'
+            ),
             toggle=True,
         )
 
@@ -497,7 +523,10 @@ class ElementDraw:
             col = layout.box().column(align=True)
             status = get_element_status_info(self, include_poll=True).status
             col.alert = status.is_error
-            col.label(text='Warning', icon='ERROR' if status.is_error else 'INFO')
+            col.label(
+                text='Warning',
+                icon=ui_icon('ERROR' if status.is_error else 'INFO'),
+            )
             for alert in alert_list:
                 col.label(text=alert)
 
@@ -508,7 +537,7 @@ class ElementDraw:
         if not self.is_draw_context_toggle_operator_bool and self.is_draw_icon:
             layout.label(text='', **icon_layout_kwargs(self.icon))
         elif reserve_space:
-            layout.label(text='', icon='BLANK1')
+            layout.label(text='', icon=ui_icon('BLANK1'))
 
     def draw_edit_icon(self, layout):
         from ..ops.select_icon import SelectIcon
@@ -522,8 +551,12 @@ class ElementDraw:
                 row.prop(self, 'icon', text='', **icon_layout_kwargs(self.icon))
             else:
                 row.alert = True
-                row.prop(self, 'icon', text='', icon='ERROR')
-            row.operator(SelectIcon.bl_idname, text='', icon='RESTRICT_SELECT_OFF')
+                row.prop(self, 'icon', text='', icon=ui_icon('ERROR'))
+            row.operator(
+                SelectIcon.bl_idname,
+                text='',
+                icon=ui_icon('RESTRICT_SELECT_OFF'),
+            )
 
     def draw_operator(self, layout):
         from .element_status import ElementStatus, get_element_status_info
@@ -572,9 +605,22 @@ class ElementDraw:
             row = layout.row(align=True)
             row.prop(self, 'operator_context')
             row.alert = is_change
-            row.prop(self.other_property, 'auto_update_element_operator_properties', icon='FILE_REFRESH', text='')
-            row.prop(self, 'operator_properties_sync_from_temp_properties', icon='SORT_DESC')
-            row.prop(self, 'operator_properties_sync_to_properties', icon='SORT_ASC')
+            row.prop(
+                self.other_property,
+                'auto_update_element_operator_properties',
+                icon=ui_icon('FILE_REFRESH'),
+                text='',
+            )
+            row.prop(
+                self,
+                'operator_properties_sync_from_temp_properties',
+                icon=ui_icon('SORT_DESC'),
+            )
+            row.prop(
+                self,
+                'operator_properties_sync_to_properties',
+                icon=ui_icon('SORT_ASC'),
+            )
 
             if is_modal:
                 layout.prop(get_pref().gesture_property, "modal_pass_view_rotation")
@@ -583,13 +629,16 @@ class ElementDraw:
             if is_change:
                 layout.alert = True
                 layout.label(text='Properties have changed. Sync them or enable auto-update.',
-                             icon='ERROR')
+                             icon=ui_icon('ERROR'))
                 layout.alert = False
             if is_modal:
                 if self.is_not_recommended_as_modal:
                     column = layout.column(align=True)
                     column.alert = True
-                    column.label(text='Not recommended as a modal operator', icon='ERROR')
+                    column.label(
+                        text='Not recommended as a modal operator',
+                        icon=ui_icon('ERROR'),
+                    )
                     column.label(text='This operator has array properties and cannot be mapped to modal events')
 
         self.draw_main_action(layout)
@@ -616,7 +665,19 @@ class ElementDraw:
         col = row.column(align=True)
         # Preferences default to EXEC; confirm tips / modifier shortcuts need invoke.
         col.operator_context = "INVOKE_DEFAULT"
-        col.operator(ElementModalOperatorEventCRUE.ADD.bl_idname, text="", icon="ADD")
-        col.operator(ElementModalOperatorEventCRUE.COPY.bl_idname, text="", icon="COPYDOWN")
-        col.operator(ElementModalOperatorEventCRUE.REMOVE.bl_idname, text="", icon="REMOVE")
+        col.operator(
+            ElementModalOperatorEventCRUE.ADD.bl_idname,
+            text="",
+            icon=ui_icon("ADD"),
+        )
+        col.operator(
+            ElementModalOperatorEventCRUE.COPY.bl_idname,
+            text="",
+            icon=ui_icon("COPYDOWN"),
+        )
+        col.operator(
+            ElementModalOperatorEventCRUE.REMOVE.bl_idname,
+            text="",
+            icon=ui_icon("REMOVE"),
+        )
         self.draw_modal_property(column)

--- a/element/element_modal_operator.py
+++ b/element/element_modal_operator.py
@@ -15,6 +15,7 @@ from ..utils.property import (
     __set_property__,
 )
 from ..utils.enum import from_rna_get_enum_items, ENUM_NUMBER_VALUE_CHANGE_MODE, ENUM_BOOL_VALUE_CHANGE_MODE
+from ..utils.icons import ui_icon
 from ..src.translate import __keymap_translate__
 
 all_event = list((e.identifier, e.name, e.description) for e in bpy.types.Event.bl_rna.properties['type'].enum_items)
@@ -619,7 +620,11 @@ class ElementModalOperatorEventItem(
         column.label(text=self.property_name)
         column.label(text=self.control_property_type)
         row.prop(self, "control_property")
-        row.operator(ElementModalOperatorEventCRUE.SelectControlProperty.bl_idname, icon="RESTRICT_SELECT_OFF", text="")
+        row.operator(
+            ElementModalOperatorEventCRUE.SelectControlProperty.bl_idname,
+            icon=ui_icon("RESTRICT_SELECT_OFF"),
+            text="",
+        )
 
         if draw_func := getattr(self, f"draw_{self.control_property_type.lower()}", None):
             draw_func(column.box())

--- a/gesture/__init__.py
+++ b/gesture/__init__.py
@@ -12,6 +12,7 @@ from ..element.element_modal_operator import ElementModalOperatorEventItem
 from ..element.element_modal_operator_cure import ElementModalOperatorEventCRUE
 from ..ops.gesture_cure import GestureCURE
 from ..utils.gesture_store import WM_STORE_ATTR
+from ..utils.icons import ui_icon
 
 
 class Gesture(
@@ -51,7 +52,9 @@ class Gesture(
         layout.separator()
         layout.label(
             text='',
-            icon='MENU_PANEL' if self.gesture_type == 'MENU' else 'MOUSE_MOVE',
+            icon=ui_icon(
+                'MENU_PANEL' if self.gesture_type == 'MENU' else 'MOUSE_MOVE'
+            ),
         )
         layout.label(text=self.name_translate, translate=False)
         if prop.gesture_show_description:

--- a/gesture/temp_keymap.py
+++ b/gesture/temp_keymap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import bpy
 
 from .addon_keymap import get_kmi_operator_properties
+from ..utils.icons import ui_icon
 
 
 def get_temp_keymap() -> bpy.types.KeyMap | None:
@@ -89,7 +90,13 @@ def draw_temp_keymap_item(
     split = box.split()
 
     row = split.row(align=True)
-    row.prop(gesture_property, "show_gesture_keymaps", text="", emboss=False, icon=show_icon)
+    row.prop(
+        gesture_property,
+        "show_gesture_keymaps",
+        text="",
+        emboss=False,
+        icon=ui_icon(show_icon),
+    )
     row.row().operator(set_key.OperatorSetKeyMaps.bl_idname)
 
     row = split.row()
@@ -109,7 +116,11 @@ def draw_temp_keymap_item(
     else:
         row.label()
 
-    row.operator(RestoreKey.bl_idname, text="", icon='BACK').item_id = kmi.id
+    row.operator(
+        RestoreKey.bl_idname,
+        text="",
+        icon=ui_icon('BACK'),
+    ).item_id = kmi.id
 
     if show_expanded:
         box = col.box()

--- a/ops/gesture_cure.py
+++ b/ops/gesture_cure.py
@@ -12,6 +12,7 @@ from ..utils.pref_access import PrefAccess
 from ..utils.active_selection import ActiveSelection
 from ..utils.structure_cache_ops import StructureCacheOps
 from ..utils.strict_json import load_json_strict
+from ..utils.icons import ui_icon
 
 
 def _preset_sort_key(gesture: dict, is_example: bool) -> tuple[bool, bool]:
@@ -124,7 +125,10 @@ class GestureCURE:
             gesture_info.label(text='Gesture: drag in a direction to choose an action.')
             menu_info = column.box()
             menu_info.label(text='Menu: open a persistent menu at the cursor and click an item.')
-            column.label(text='The type is fixed after creation.', icon='INFO')
+            column.label(
+                text='The type is fixed after creation.',
+                icon=ui_icon('INFO'),
+            )
 
         def execute(self, _):
             from ..utils.gesture_store import get_gesture_store, get_gestures

--- a/ops/menu.py
+++ b/ops/menu.py
@@ -60,7 +60,9 @@ class GestureMenuOperator(PublicOperator, GestureMenuRuntime):
 
     @staticmethod
     def _draw_error(menu, _context):
-        menu.layout.label(text='Menu gesture not found', icon='ERROR')
+        from ..utils.icons import ui_icon
+
+        menu.layout.label(text='Menu gesture not found', icon=ui_icon('ERROR'))
         menu.layout.label(text='Restore or recreate its shortcut in preferences')
 
     def _activate_existing_menu(self, gesture) -> bool:
@@ -84,10 +86,12 @@ class GestureMenuOperator(PublicOperator, GestureMenuRuntime):
         gestures = get_gestures()
         gesture = gestures.get(self.gesture) if gestures is not None else None
         if gesture is None or gesture.gesture_type != 'MENU':
+            from ..utils.icons import ui_icon
+
             context.window_manager.popup_menu(
                 self.__class__._draw_error,
                 title=pgettext('Error'),
-                icon='ERROR',
+                icon=ui_icon('ERROR'),
             )
             return {'CANCELLED'}
 

--- a/ops/quick_add/create_element_property.py
+++ b/ops/quick_add/create_element_property.py
@@ -15,6 +15,7 @@ from ...utils.property_data import (
 from ...utils.public import get_pref, PublicOperator, debug_print
 from ...utils.pref_access import PrefAccess
 from ...utils.structure_cache_ops import StructureCacheOps
+from ...utils.icons import ui_icon
 
 
 def gesture_control_property_error(pointer, rna_prop) -> str | None:
@@ -308,7 +309,7 @@ class Draw(PublicOperator, PrefAccess, StructureCacheOps, OpsProperty):
         box.label(text="Gesture-Controlled Property")
         control_error = gesture_control_property_error(self.button_pointer, prop)
         if control_error:
-            box.label(text=control_error, icon='LOCKED')
+            box.label(text=control_error, icon=ui_icon('LOCKED'))
             box.enabled = False
         else:
             box.label(text="Shows the live value and changes it directly from the gesture")

--- a/ops/quick_add/create_panel_menu.py
+++ b/ops/quick_add/create_panel_menu.py
@@ -8,6 +8,7 @@ from ...utils.panel import iter_menu_classes, iter_panel_classes
 from ...utils.public import PublicOperator, get_pref, poll_message_active_gesture
 from ...utils.structure_cache_ops import StructureCacheOps
 from ...utils.session_state import SessionState
+from ...utils.icons import ui_icon
 
 
 class CreatePanelMenu(PublicOperator, StructureCacheOps):
@@ -83,7 +84,11 @@ def draw_add(self, context):
     ops.create_id_name = self.bl_idname
     rr = row.row(align=True)
     rr.operator_context = "INVOKE_DEFAULT"
-    rr.operator(CreatePanelMenu.bl_idname, text="", icon="PANEL_CLOSE")
+    rr.operator(
+        CreatePanelMenu.bl_idname,
+        text="",
+        icon=ui_icon("PANEL_CLOSE"),
+    )
 
 
 exclude_panel = ["PROPERTIES_PT_navigation_bar"]

--- a/ops/select_icon.py
+++ b/ops/select_icon.py
@@ -11,7 +11,11 @@ from bpy.props import BoolProperty, EnumProperty, StringProperty
 from bpy_extras.io_utils import ExportHelper, ImportHelper
 
 from ..utils.public import get_pref, poll_message_active_element, poll_addon_preferences
-from ..utils.icons import icon_layout_kwargs, CUSTOM_ICONS_EXPORT_FILENAME
+from ..utils.icons import (
+    CUSTOM_ICONS_EXPORT_FILENAME,
+    icon_layout_kwargs,
+    ui_icon,
+)
 
 DPI = 72
 POPUP_PADDING = 10
@@ -154,7 +158,7 @@ class SelectIcon(bpy.types.Operator):
             hi.alignment = 'CENTER'
             hi.label(text='History')
             self.draw_icons(hi.column(align=True), num_cols, icons=history)
-            hi.operator(ClearHistory.bl_idname, icon='PANEL_CLOSE')
+            hi.operator(ClearHistory.bl_idname, icon=ui_icon('PANEL_CLOSE'))
 
         row = col.box().row()
         row.alignment = 'CENTER'
@@ -169,9 +173,9 @@ class SelectIcon(bpy.types.Operator):
 
         row = box.row()
         row.separator()
-        row.operator(RefreshIcons.bl_idname, icon='FILE_REFRESH')
+        row.operator(RefreshIcons.bl_idname, icon=ui_icon('FILE_REFRESH'))
         row.separator()
-        row.operator(OpenCustomIconFolder.bl_idname, icon='FILE_FOLDER')
+        row.operator(OpenCustomIconFolder.bl_idname, icon=ui_icon('FILE_FOLDER'))
         row.separator()
 
         box = col.box()
@@ -182,15 +186,15 @@ class SelectIcon(bpy.types.Operator):
         header = layout.box()
         header = header.row()
         row = header.row(align=True)
-        row.prop(self, 'show_event_icons', text='', icon='HAND')
+        row.prop(self, 'show_event_icons', text='', icon=ui_icon('HAND'))
         row.separator()
 
         row.prop(
             self, 'copy_on_select', text='',
-            icon='COPYDOWN', toggle=True)
+            icon=ui_icon('COPYDOWN'), toggle=True)
         row.separator()
 
-        row.prop(self, 'filter', text='', icon='VIEWZOOM')
+        row.prop(self, 'filter', text='', icon=ui_icon('VIEWZOOM'))
 
     def draw_icons(self, layout, num_cols=0, icons=None):
         if icons is not None:
@@ -233,7 +237,7 @@ class SelectIcon(bpy.types.Operator):
 
         if col_idx != 0 and not icons and i >= num_cols:
             for _ in range(num_cols - col_idx):
-                row.label(text="", icon='BLANK1')
+                row.label(text="", icon=ui_icon('BLANK1'))
 
         if not filtered_icons:
             row.label(text="No icons were found")

--- a/ops/set_key.py
+++ b/ops/set_key.py
@@ -10,6 +10,7 @@ from ..utils.public import (
 from ..utils.pref_access import PrefAccess
 from ..utils.active_selection import ActiveSelection
 from ..utils.public_ui import icon_two
+from ..utils.icons import ui_icon
 
 # Matches default gesture keymaps and other frequent editor contexts.
 COMMON_GESTURE_KEYMAPS = frozenset({
@@ -156,14 +157,31 @@ class OperatorSetKeyMaps(PublicOperator, PrefAccess, ActiveSelection):
         searching = bool(self.keymap_search.strip())
         box = layout.box()
         header = box.row(align=True)
-        header.label(text="Keymap list", icon='KEYINGSET')
+        header.label(text="Keymap list", icon=ui_icon('KEYINGSET'))
         row = box.row(align=True)
         row.scale_y = 1.1
         row.enabled = not searching
-        row.prop_enum(self, "keymap_filter", 'COMMON', text="Frequently Used", icon='SOLO_ON')
-        row.prop_enum(self, "keymap_filter", 'ALL', text="All", icon='PRESET')
+        row.prop_enum(
+            self,
+            "keymap_filter",
+            'COMMON',
+            text="Frequently Used",
+            icon=ui_icon('SOLO_ON'),
+        )
+        row.prop_enum(
+            self,
+            "keymap_filter",
+            'ALL',
+            text="All",
+            icon=ui_icon('PRESET'),
+        )
         search_row = box.row(align=True)
-        search_row.prop(self, "keymap_search", text="", icon='VIEWZOOM')
+        search_row.prop(
+            self,
+            "keymap_search",
+            text="",
+            icon=ui_icon('VIEWZOOM'),
+        )
 
     def draw(self, _):
         OperatorSetKeyMaps.__session_keymap_filter__ = self.keymap_filter
@@ -204,14 +222,14 @@ class OperatorSetKeyMaps(PublicOperator, PrefAccess, ActiveSelection):
         if not selected:
             row = layout.row()
             row.enabled = False
-            row.label(text="—", icon='BLANK1')
+            row.label(text="—", icon=ui_icon('BLANK1'))
             return
         for name in selected:
             text = __keymap_translate__(name)
             # Already translated; disable UI auto-translate (e.g. Screen → 滤色).
             layout.operator(
                 self.bl_idname,
-                icon='RESTRICT_SELECT_OFF',
+                icon=ui_icon('RESTRICT_SELECT_OFF'),
                 text=text,
                 translate=False,
             ).add_keymap = name
@@ -221,7 +239,11 @@ class OperatorSetKeyMaps(PublicOperator, PrefAccess, ActiveSelection):
         row = layout.row(align=True)
         row.label(text=__keymap_translate__(name), translate=False)
         select_icon = icon_two(name in OperatorSetKeyMaps.__temp_selected_keymaps__, 'RESTRICT_SELECT')
-        row.operator(OperatorSetKeyMaps.bl_idname, text='', icon=select_icon).add_keymap = name
+        row.operator(
+            OperatorSetKeyMaps.bl_idname,
+            text='',
+            icon=ui_icon(select_icon),
+        ).add_keymap = name
 
     def draw_keymaps_flat(self, layout, items, query: str):
         """Flat search results: match English or translated names, no folding."""
@@ -231,7 +253,7 @@ class OperatorSetKeyMaps(PublicOperator, PrefAccess, ActiveSelection):
         if not matched:
             row = layout.row()
             row.enabled = False
-            row.label(text="No matching keymaps", icon='INFO')
+            row.label(text="No matching keymaps", icon=ui_icon('INFO'))
             return
         for name in matched:
             self._draw_keymap_row(layout, name)
@@ -251,7 +273,11 @@ class OperatorSetKeyMaps(PublicOperator, PrefAccess, ActiveSelection):
                 if child:
                     row.prop(keymap, 'show_expanded_items', text='')
                 select_icon = icon_two(name in OperatorSetKeyMaps.__temp_selected_keymaps__, 'RESTRICT_SELECT')
-                row.operator(OperatorSetKeyMaps.bl_idname, text='', icon=select_icon).add_keymap = keymap.name
+                row.operator(
+                    OperatorSetKeyMaps.bl_idname,
+                    text='',
+                    icon=ui_icon(select_icon),
+                ).add_keymap = keymap.name
                 if show_child and child:
                     child_box = column.box()
                     self.draw_keymaps(child_box.column(align=True), child)

--- a/ops/set_poll.py
+++ b/ops/set_poll.py
@@ -5,6 +5,7 @@ from ..utils.poll_data import PollData
 from ..utils.public import PublicOperator, poll_message_active_element
 from ..utils.active_selection import ActiveSelection
 from ..src.translate import __name_translate__
+from ..utils.icons import ui_icon
 
 
 class SetPollExpression(ActiveSelection, PublicOperator, PollData):
@@ -85,7 +86,7 @@ class SetPollExpression(ActiveSelection, PublicOperator, PollData):
         col = layout.column()
         element = self.element
         if element is None:
-            col.label(text='No active element', icon='ERROR')
+            col.label(text='No active element', icon=ui_icon('ERROR'))
             return
         is_alert = element.is_alert
         cc = col.column(align=True)
@@ -94,7 +95,7 @@ class SetPollExpression(ActiveSelection, PublicOperator, PollData):
         sp.label(text='Prerequisite:')
         sp.prop(self.element, 'poll_string', text='')
         if is_alert:
-            cc.label(text='Invalid expression', icon='ERROR')
+            cc.label(text='Invalid expression', icon=ui_icon('ERROR'))
             cc.operator_context = "EXEC_DEFAULT"
             cc.operator(self.bl_idname, text=__name_translate__("Clear")).clear = True
         self.draw_logical_operator(col)

--- a/preferences/backups.py
+++ b/preferences/backups.py
@@ -16,6 +16,7 @@ from ..utils.backups import (
     resolve_backups_folder,
 )
 from ..utils.property import set_property, get_property
+from ..utils.icons import ui_icon
 
 
 def _on_max_auto_backups_update(self, _context):
@@ -135,7 +136,11 @@ class BackupsProperty(bpy.types.PropertyGroup):
         path_row = path_box.row(align=True)
         path_row.label(text=gesture_path, translate=False)
         folder = os.path.dirname(gesture_path) if gesture_path else active_folder
-        path_row.operator("wm.path_open", text="", icon='FILE_FOLDER').filepath = folder
+        path_row.operator(
+            "wm.path_open",
+            text="",
+            icon=ui_icon('FILE_FOLDER'),
+        ).filepath = folder
 
         folder_box = box.box()
         folder_box.use_property_split = False
@@ -143,7 +148,7 @@ class BackupsProperty(bpy.types.PropertyGroup):
         folder_box_row = folder_box.row(align=True)
         folder_box_row.label(text=default_folder, translate=False)
         folder_box_row.operator(
-            "wm.path_open", text="", icon='FILE_FOLDER'
+            "wm.path_open", text="", icon=ui_icon('FILE_FOLDER')
         ).filepath = default_folder
 
         if active_folder != default_folder:
@@ -152,7 +157,7 @@ class BackupsProperty(bpy.types.PropertyGroup):
             active_row = folder_box.row(align=True)
             active_row.label(text=active_folder, translate=False)
             active_row.operator(
-                "wm.path_open", text="", icon='FILE_FOLDER'
+                "wm.path_open", text="", icon=ui_icon('FILE_FOLDER')
             ).filepath = active_folder
 
         backup_count, backup_bytes = get_rotating_backup_stats(active_folder)
@@ -166,7 +171,11 @@ class BackupsProperty(bpy.types.PropertyGroup):
         )
         clear_row = stats_row.row(align=True)
         clear_row.enabled = backup_count > 0
-        clear_row.operator("wm.gesture_clear_backups", text="", icon='TRASH')
+        clear_row.operator(
+            "wm.gesture_clear_backups",
+            text="",
+            icon=ui_icon('TRASH'),
+        )
 
         folder_box.prop(backups, 'max_auto_backups')
 

--- a/preferences/draw.py
+++ b/preferences/draw.py
@@ -1,6 +1,7 @@
 import bpy
 
 from .draw_gesture import GestureDraw
+from ..utils.icons import ui_icon
 from ..utils.public import get_pref
 from ..utils.ui_draw_sync import (
     get_frozen_active_element,
@@ -86,13 +87,17 @@ class PreferencesDraw(GestureDraw):
         rr.enabled = not message
         rr.operator_context = "EXEC_DEFAULT"
         rr.prop(pref, 'enabled', text="", emboss=True)
-        rr.operator("wm.gesture_save_userpref", text="", icon="FILE_TICK")
+        rr.operator(
+            "wm.gesture_save_userpref",
+            text="",
+            icon=ui_icon("FILE_TICK"),
+        )
 
         row.prop(pref, 'show_page', expand=True)
         if message:
             status = row.row(align=True)
             status.enabled = False
-            status.label(text=message, icon="PAUSE")
+            status.label(text=message, icon=ui_icon("PAUSE"))
         if is_panel_pause_source_active(bpy.context):
             toggle = row.row(align=True)
             toggle.enabled = True
@@ -135,10 +140,26 @@ class PreferencesDraw(GestureDraw):
         icon_row.label(text="Custom Icons")
         icon_ops = icon_row.row(align=True)
         icon_ops.operator_context = "INVOKE_DEFAULT"
-        icon_ops.operator(OpenCustomIconFolder.bl_idname, text="", icon="FILE_FOLDER")
-        icon_ops.operator(RefreshIcons.bl_idname, text="", icon="FILE_REFRESH")
-        icon_ops.operator(ExportCustomIcons.bl_idname, text="", icon="EXPORT")
-        icon_ops.operator(ImportCustomIcons.bl_idname, text="", icon="IMPORT")
+        icon_ops.operator(
+            OpenCustomIconFolder.bl_idname,
+            text="",
+            icon=ui_icon("FILE_FOLDER"),
+        )
+        icon_ops.operator(
+            RefreshIcons.bl_idname,
+            text="",
+            icon=ui_icon("FILE_REFRESH"),
+        )
+        icon_ops.operator(
+            ExportCustomIcons.bl_idname,
+            text="",
+            icon=ui_icon("EXPORT"),
+        )
+        icon_ops.operator(
+            ImportCustomIcons.bl_idname,
+            text="",
+            icon=ui_icon("IMPORT"),
+        )
         icon_box.label(
             text="Put PNG files in the custom icons folder to use them as gesture element icons"
         )

--- a/preferences/draw_element.py
+++ b/preferences/draw_element.py
@@ -83,7 +83,13 @@ class DrawElement:
             column.separator()
             icon = ui_icon(icon_two(draw_property.element_show_left_side, style='ALIGN'))
             column.alert = draw_property.element_show_left_side
-            column.prop(draw_property, 'element_show_left_side', icon=icon, text='', emboss=False)
+            column.prop(
+                draw_property,
+                'element_show_left_side',
+                icon=ui_icon(icon),
+                text='',
+                emboss=False,
+            )
 
     @staticmethod
     def draw_property(

--- a/preferences/draw_gesture.py
+++ b/preferences/draw_gesture.py
@@ -2,6 +2,7 @@ import bpy
 
 from .draw_element import DrawElement
 from ..ops import export_import
+from ..utils.icons import ui_icon
 from ..utils.public import get_pref
 
 
@@ -26,23 +27,51 @@ class GestureDraw:
         # Preferences default to EXEC; confirm tips / modifier shortcuts need invoke.
         column.operator_context = "INVOKE_DEFAULT"
 
-        column.operator(GestureCURE.ADD.bl_idname, icon='ADD', text='')
-        column.operator(GestureCURE.COPY.bl_idname, text='', icon='COPYDOWN')
-        column.operator(GestureCURE.REMOVE.bl_idname, text='', icon='REMOVE')
+        column.operator(GestureCURE.ADD.bl_idname, icon=ui_icon('ADD'), text='')
+        column.operator(
+            GestureCURE.COPY.bl_idname,
+            text='',
+            icon=ui_icon('COPYDOWN'),
+        )
+        column.operator(
+            GestureCURE.REMOVE.bl_idname,
+            text='',
+            icon=ui_icon('REMOVE'),
+        )
 
         column.separator()
 
         sort_column = column.column(align=True)
-        sort_column.operator(GestureCURE.SORT.bl_idname, icon='SORT_DESC', text='').is_next = False
+        sort_column.operator(
+            GestureCURE.SORT.bl_idname,
+            icon=ui_icon('SORT_DESC'),
+            text='',
+        ).is_next = False
 
-        sort_column.operator(GestureCURE.SORT.bl_idname, icon='SORT_ASC', text='').is_next = True
+        sort_column.operator(
+            GestureCURE.SORT.bl_idname,
+            icon=ui_icon('SORT_ASC'),
+            text='',
+        ).is_next = True
 
         column.separator()
 
         import_id_name = export_import.Import.bl_idname
-        column.operator(export_import.Export.bl_idname, icon='EXPORT', text='')
-        column.operator(import_id_name, icon='ASSET_MANAGER', text='').preset_show = True
-        column.operator(import_id_name, icon='IMPORT', text='').preset_show = False
+        column.operator(
+            export_import.Export.bl_idname,
+            icon=ui_icon('EXPORT'),
+            text='',
+        )
+        column.operator(
+            import_id_name,
+            icon=ui_icon('ASSET_MANAGER'),
+            text='',
+        ).preset_show = True
+        column.operator(
+            import_id_name,
+            icon=ui_icon('IMPORT'),
+            text='',
+        ).preset_show = False
 
     @staticmethod
     def draw_gesture_key(

--- a/release-notes/v2.4.0.md
+++ b/release-notes/v2.4.0.md
@@ -1,0 +1,15 @@
+2026-7-30 v2.4.0
+新增: 可保持开启并同时显示多个持久菜单，新增 Common Menu 侧键预设
+新增: Row、Column、Box、Split、Label 布局元素，主题预设、可拖动预览选择器和运行时工具提示
+新增: Blender 风格数值控件，支持箭头、滚轮、拖动、Backspace 重置和 Alt 同步到所选对象
+修复: 输入事件、预览与菜单生命周期、事务式导入与持久化，以及仅清理扩展自有快捷键
+优化: 大型元素面板分页、离屏裁剪和静态 GPU 绘制命令缓存
+兼容性: 最低版本调整为 Blender 4.3；支持新版 Grease Pencil 标识符；使用受限 AST 解析器替代 eval/exec
+
+2026-7-30 v2.4.0
+New: Keep persistent menus open and show multiple menus together; add the Common Menu side-button preset
+New: Add Row, Column, Box, Split, and Label layouts, theme presets, a draggable preview selector, and runtime tooltips
+New: Add Blender-style numeric controls with arrows, wheel input, scrubbing, Backspace reset, and Alt copy to selected objects
+Fix: Improve input handling, preview and menu lifecycles, transactional import and persistence, and owned-keymap cleanup
+Optimize: Paginate large element panels, cull off-screen layouts, and retain static GPU drawing commands
+Compatibility: Require Blender 4.3+, support current Grease Pencil identifiers, and replace eval/exec with a restricted AST parser

--- a/tests/test_ui_icons.py
+++ b/tests/test_ui_icons.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).parents[1]
+UI_SOURCE_ROOTS = ("element", "gesture", "ops", "preferences", "ui")
+UI_LAYOUT_METHODS = {"label", "menu", "operator", "popover", "prop", "prop_enum"}
+
+
+class UILayoutIconTests(unittest.TestCase):
+    def test_every_explicit_ui_icon_uses_the_version_safe_helper(self):
+        failures = []
+        for root_name in UI_SOURCE_ROOTS:
+            for path in sorted((REPOSITORY / root_name).rglob("*.py")):
+                source = path.read_text(encoding="utf-8")
+                tree = ast.parse(source, filename=str(path))
+                for node in ast.walk(tree):
+                    if not (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr in UI_LAYOUT_METHODS
+                    ):
+                        continue
+                    for keyword in node.keywords:
+                        if keyword.arg != "icon":
+                            continue
+                        safe = (
+                            isinstance(keyword.value, ast.Call)
+                            and isinstance(keyword.value.func, ast.Name)
+                            and keyword.value.func.id == "ui_icon"
+                        )
+                        if not safe:
+                            failures.append(
+                                f"{path.relative_to(REPOSITORY)}:{node.lineno}"
+                            )
+
+        self.assertEqual([], failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/context_menu.py
+++ b/ui/context_menu.py
@@ -9,6 +9,7 @@ from ..ops.quick_add.create_element_property import (
 from ..utils.public import get_pref
 from ..utils.session_state import SessionState
 from ..utils.translate import translate_rna_text
+from ..utils.icons import ui_icon
 
 
 class ContextMenu(bpy.types.Menu):
@@ -33,11 +34,25 @@ class ContextMenu(bpy.types.Menu):
         layout = self.layout
 
         if button_pointer and button_pointer.__class__.__name__ == "BlExtDummyGroup":
-            layout.label(text="Add gesture", icon="GEOMETRY_SET" if bpy.app.version >= (4, 3, 0) else "VIEW_PAN")
+            layout.label(
+                text="Add gesture",
+                icon=ui_icon(
+                    "GEOMETRY_SET"
+                    if bpy.app.version >= (4, 3, 0)
+                    else "VIEW_PAN"
+                ),
+            )
             layout.label(text="Dynamic enum properties cannot be added")
         elif (show_operator or show_property) and show:
             layout.context_pointer_set('show_gesture_add_menu', self)
-            layout.label(text="Add gesture", icon="GEOMETRY_SET" if bpy.app.version >= (4, 3, 0) else "VIEW_PAN")
+            layout.label(
+                text="Add gesture",
+                icon=ui_icon(
+                    "GEOMETRY_SET"
+                    if bpy.app.version >= (4, 3, 0)
+                    else "VIEW_PAN"
+                ),
+            )
             layout.enabled = get_pref().active_gesture is not None
             if show_property:
                 prop_type = button_prop.type
@@ -64,7 +79,7 @@ class ContextMenu(bpy.types.Menu):
                             pgettext("Add Gesture-Controlled Property %s")
                             % property_name
                         ),
-                        icon='LOCKED' if control_error else 'MOUSE_MOVE',
+                        icon=ui_icon('LOCKED' if control_error else 'MOUSE_MOVE'),
                     )
                     operator.display_property = True
                     operator.property_type = prop_type
@@ -85,7 +100,11 @@ class ContextMenu(bpy.types.Menu):
                 rr.operator(CreateElementOperator.bl_idname, text=pgettext("Add Operator %s to Gesture") % text)
                 rr = row
                 rr.operator_context = "INVOKE_DEFAULT"
-                rr.operator(CreateElementOperator.bl_idname, text="Modal Operator", icon="PRESET_NEW")
+                rr.operator(
+                    CreateElementOperator.bl_idname,
+                    text="Modal Operator",
+                    icon=ui_icon("PRESET_NEW"),
+                )
 
 
 _context_menu_appended = False

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -8,6 +8,7 @@ from ..utils.active_selection import ActiveSelection
 from ..utils.pref_access import PrefAccess
 from ..utils.public import get_pref
 from ..utils.rna_register import register_classes_safe, unregister_classes_safe
+from ..utils.icons import ui_icon
 
 _MODAL_EVENT_VISIBILITY: dict[int, bool] = {}
 
@@ -56,13 +57,17 @@ class GesturePanel(bpy.types.Panel, PrefAccess, ActiveSelection):
         rr.enabled = not message
         rr.operator_context = "EXEC_DEFAULT"
         rr.prop(pref, 'enabled', text="", emboss=True)
-        rr.operator("wm.gesture_save_userpref", text="", icon="FILE_TICK")
+        rr.operator(
+            "wm.gesture_save_userpref",
+            text="",
+            icon=ui_icon("FILE_TICK"),
+        )
         self.draw_label_ang_version(row)
 
         if message:
             status = row.row(align=True)
             status.enabled = False
-            status.label(text=message, icon="PAUSE")
+            status.label(text=message, icon=ui_icon("PAUSE"))
         if is_panel_pause_source_active(context):
             toggle = row.row(align=True)
             toggle.enabled = True
@@ -80,7 +85,11 @@ class GesturePanel(bpy.types.Panel, PrefAccess, ActiveSelection):
         layout = self.layout
         layout.enabled = not heavy_panel_skip_message(context)
         layout.operator_context = "EXEC_DEFAULT"
-        layout.operator("wm.gesture_show_preferences", text="", icon="PREFERENCES")
+        layout.operator(
+            "wm.gesture_show_preferences",
+            text="",
+            icon=ui_icon("PREFERENCES"),
+        )
 
     def draw(self, context):
         ...

--- a/ui/ui_list.py
+++ b/ui/ui_list.py
@@ -4,6 +4,7 @@ from bpy.props import IntProperty, StringProperty
 from ..utils.pref_access import PrefAccess
 from ..utils.active_selection import ActiveSelection
 from ..utils.public_ui import icon_two
+from ..utils.icons import ui_icon
 
 _ELEMENT_TREE_FULL_DRAW_LIMIT = 48
 _ELEMENT_TREE_PAGE_SIZE = 32
@@ -109,13 +110,23 @@ class GestureUIList(bpy.types.UIList, PrefAccess, ActiveSelection):
         row.prop(prop, "gesture_keymap_split_factor")
 
         row = column.row(align=True)
-        row.prop(prop, "gesture_remove_tips", icon="INFO_LARGE" if bpy.app.version >= (4, 3, 0) else "ERROR")
-        row.prop(prop, "enable_name_translation", icon="BLANK1")
+        row.prop(
+            prop,
+            "gesture_remove_tips",
+            icon=ui_icon(
+                "INFO_LARGE" if bpy.app.version >= (4, 3, 0) else "ERROR"
+            ),
+        )
+        row.prop(prop, "enable_name_translation", icon=ui_icon("BLANK1"))
 
         row = column.row(align=True)
-        row.prop(prop, 'gesture_show_enabled_button', icon=icon_two(prop.gesture_show_enabled_button, "HIDE"))
-        row.prop(prop, 'gesture_show_keymap', icon="BLANK1")
-        row.prop(prop, 'gesture_show_description', icon="INFO")
+        row.prop(
+            prop,
+            'gesture_show_enabled_button',
+            icon=ui_icon(icon_two(prop.gesture_show_enabled_button, "HIDE")),
+        )
+        row.prop(prop, 'gesture_show_keymap', icon=ui_icon("BLANK1"))
+        row.prop(prop, 'gesture_show_description', icon=ui_icon("INFO"))
 
 
 class ElementUIList(bpy.types.UIList, PrefAccess, ActiveSelection):
@@ -196,7 +207,7 @@ class ElementUIList(bpy.types.UIList, PrefAccess, ActiveSelection):
         operator = previous.operator(
             ElementTreePage.bl_idname,
             text='',
-            icon='TRIA_LEFT',
+            icon=ui_icon('TRIA_LEFT'),
         )
         operator.root_pointer = str(root_pointer)
         operator.page = max(0, page - 1)
@@ -206,7 +217,7 @@ class ElementUIList(bpy.types.UIList, PrefAccess, ActiveSelection):
         operator = following.operator(
             ElementTreePage.bl_idname,
             text='',
-            icon='TRIA_RIGHT',
+            icon=ui_icon('TRIA_RIGHT'),
         )
         operator.root_pointer = str(root_pointer)
         operator.page = min(page_count - 1, page + 1)
@@ -231,19 +242,25 @@ class ElementUIList(bpy.types.UIList, PrefAccess, ActiveSelection):
         row = column.row(align=True)
         prop = self.draw_property
         icon = icon_two(prop.element_show_enabled_button, 'HIDE')
-        row.prop(prop, 'element_show_enabled_button', icon=icon)
+        row.prop(prop, 'element_show_enabled_button', icon=ui_icon(icon))
         if getattr(context.area, 'type', None) == 'PREFERENCES':
             icon = icon_two(prop.element_show_left_side, 'ALIGN')
-            row.prop(prop, 'element_show_left_side', icon=icon)
+            row.prop(prop, 'element_show_left_side', icon=ui_icon(icon))
 
         row = column.row(align=True)
         icon = icon_two(prop.element_show_icon, 'HIDE')
-        row.prop(prop, 'element_show_icon', icon=icon)
+        row.prop(prop, 'element_show_icon', icon=ui_icon(icon))
 
         row = column.row(align=True)
-        row.prop(prop, "element_remove_tips", icon="INFO_LARGE" if bpy.app.version >= (4, 3, 0) else "ERROR")
+        row.prop(
+            prop,
+            "element_remove_tips",
+            icon=ui_icon(
+                "INFO_LARGE" if bpy.app.version >= (4, 3, 0) else "ERROR"
+            ),
+        )
         row.operator(ElementCURE.SwitchShowChild.bl_idname)
-        row.prop(prop, "enable_name_translation", icon="BLANK1")
+        row.prop(prop, "enable_name_translation", icon=ui_icon("BLANK1"))
 
 
 class ElementModalEventUIList(bpy.types.UIList, PrefAccess, ActiveSelection):
@@ -263,8 +280,19 @@ class ImportPresetUIList(bpy.types.UIList, PrefAccess, ActiveSelection):
 
         left = layout.row()
         left.alignment = 'LEFT'
-        left.prop(item, 'selected', text=item.name, translate=False, icon='NONE')
+        left.prop(
+            item,
+            'selected',
+            text=item.name,
+            translate=False,
+            icon=ui_icon('NONE'),
+        )
 
         right = layout.row()
         right.alignment = 'RIGHT'
-        right.prop(item, 'selected', icon=icon_two(item.selected, 'RESTRICT_SELECT'), text='')
+        right.prop(
+            item,
+            'selected',
+            icon=ui_icon(icon_two(item.selected, 'RESTRICT_SELECT')),
+            text='',
+        )


### PR DESCRIPTION
- Updated gesture module to use ui_icon for MENU_PANEL and MOUSE_MOVE icons
- Replaced FILE_FOLDER icon with ui_icon in preferences backups module
- Changed TRASH icon to use ui_icon function in backup clearing operation
- Updated context menu to use ui_icon for GEOMETRY_SET and VIEW_PAN icons
- Replaced LOCKED and MOUSE_MOVE icons with ui_icon function calls
- Changed PRESET_NEW icon to use ui_icon in quick add operators
- Updated various UI elements to use ui_icon for FILE_TICK, PAUSE, FILE_FOLDER
- Replaced REFRESH, EXPORT, IMPORT, ASSET_MANAGER icons with ui_icon calls
- Changed ADD, COPYDOWN, REMOVE, SORT_DESC, SORT_ASC icons to use ui_icon
- Updated UV_SYNC_SELECT, PASTEFLIPDOWN, GEOMETRY_NODES icons with ui_icon
- Replaced CON_CHILDOF, SPLIT_HORIZONTAL, BLANK1 icons using ui_icon function
- Changed ERROR, HIDE_OFF, FILTER, TRIA_DOWN, TRIA_RIGHT icons to ui_icon calls
- Updated ARROW_LEFTRIGHT, RESTRICT_SELECT_OFF, RADIOBUT_ON, RADIOBUT_OFF icons
- Replaced INFO, FILE_REFRESH, RESTRICT_SELECT icons with ui_icon function
- Updated HAND, COPYDOWN, VIEWZOOM, KEYINGSET, SOLO_ON, PRESET icons to ui_icon
- Changed BLANK1, RESTRICT_SELECT_OFF, INFO icons in various UI components