### PR TITLE
feat(tests): add unit tests for Maya Operator preset to verify inset …

### DIFF
--- a/src/preset/Maya Operator.json
+++ b/src/preset/Maya Operator.json
@@ -711,7 +711,7 @@
                   "icon": "SNAP_FACE_CENTER",
                   "enabled_icon": true,
                   "direction": "2",
-                  "operator_bl_idname": "mesh.poke"
+                  "operator_bl_idname": "mesh.inset"
                 },
                 "1": {
                   "name": "Solidify Faces",

--- a/tests/test_maya_operator_preset.py
+++ b/tests/test_maya_operator_preset.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).parents[1]
+PRESET_PATH = ROOT / "src" / "preset" / "Maya Operator.json"
+
+
+def _reject_duplicate_keys(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise AssertionError(f"Duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _element_values(element):
+    yield element
+    for child in element.get("element", {}).values():
+        yield from _element_values(child)
+
+
+class MayaOperatorPresetTests(unittest.TestCase):
+    def test_inset_faces_uses_the_inset_operator(self):
+        with PRESET_PATH.open(encoding="utf-8") as handle:
+            preset = json.load(handle, object_pairs_hook=_reject_duplicate_keys)
+
+        inset_faces = [
+            element
+            for gesture in preset["gesture"].values()
+            for root in gesture.get("element", {}).values()
+            for element in _element_values(root)
+            if element.get("name") == "Inset Faces"
+        ]
+
+        self.assertEqual(len(inset_faces), 1)
+        self.assertEqual(inset_faces[0].get("operator_bl_idname"), "mesh.inset")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修改内容

Fixes #47

修复 Maya Operator 预设中“内插面（Inset Faces）”的操作绑定错误：

- 原先错误调用 `mesh.poke`，因此界面显示并执行“尖分面”
- 现改为 `mesh.inset`，使名称、提示与实际操作一致
- 新增回归测试，防止该预设再次误绑定
- ~~其实是codex跑的~~
- （其实直接在个人配置中直接盖掉就行）
- （这是子布第一次提PR请求，可能会有错）